### PR TITLE
adding amixer mute example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Volume using alsa:
 ```
 bindsym XF86AudioRaiseVolume exec amixer -q set Master 2%+ unmute && amixer sget Master | grep 'Right:' | awk -F'[][]' '{ print substr($2, 0, length($2)-1) }' > $SWAYSOCK.wob
 bindsym XF86AudioLowerVolume exec amixer -q set Master 2%- unmute && amixer sget Master | grep 'Right:' | awk -F'[][]' '{ print substr($2, 0, length($2)-1) }' > $SWAYSOCK.wob
+bindsym XF86AudioMute exec (amixer get Master | grep off > /dev/null && amixer -q set Master unmute && amixer sget Master | grep 'Right:' | awk -F'[][]' '{ print substr($2, 0, length($2)-1) }' > $SWAYSOCK.wob) || (amixer -q set Master mute && echo 0 > $SWAYSOCK.wob)
 ```
 
 Volume using pulse audio:


### PR DESCRIPTION
Mute was missing as an example command so I had to google around how to do this, not sure this was the most efficient way to do this but I combined an example from https://www.commandlinefu.com/commands/using/amixer to build this mute/unmute command toggle for sway.